### PR TITLE
Fix/formatval unicode

### DIFF
--- a/csquery/structured.py
+++ b/csquery/structured.py
@@ -9,10 +9,17 @@
 from __future__ import division, print_function, absolute_import, unicode_literals  # NOQA
 
 from collections import OrderedDict
+import six
 
 
 def escape(string):
     return string.replace("'", "\'").replace('\\', '\\\\')
+
+
+def text_(s, encoding='utf-8', errors='strict'):
+    if isinstance(s, six.binary_type):
+        return s.decode(encoding, errors)
+    return s  # pragma: no cover
 
 
 def format_value(value):
@@ -21,15 +28,18 @@ def format_value(value):
     if type(value) == Expression:
         return value()
     try:
+        # if format_value's input only text_type, this sentence is unnecessary.
+        value = text_(value)
+
         if (value.startswith('(') and value.endswith(')'))\
                 or (value.startswith('{') and value.endswith(']'))\
                 or (value.startswith('[') and value.endswith('}'))\
                 or (value.startswith('[') and value.endswith(']'))\
                 or (value.startswith("'") and value.endswith("'"))\
                 or ('=' in value):
-            return str(escape(value))
+            return six.text_type(escape(value))
     except AttributeError:
-        return str(value)
+        return six.text_type(value)
     return "'{}'".format(escape(value))
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,9 @@ with open(os.path.join(here, 'csquery', '__init__.py'), 'r') as f:
 
 readme = open(os.path.join(here, 'README.rst')).read()
 
-requires = []
+requires = [
+    'six'
+]
 
 tests_require = [
     'pytest-cov',

--- a/tests/test_structured.py
+++ b/tests/test_structured.py
@@ -107,6 +107,19 @@ class TestFormatValue(object):
             field("Alec'Guinness", 'actors')
         )
 
+    def test_it__with_multi_encoding(self):
+        from csquery.structured import Expression
+        import six
+        binary_value = six.binary_type("あ")
+        text_value = six.text_type("あ")
+
+        self._call_fut(
+            Expression('and', title=binary_value)
+        )
+        self._call_fut(
+            Expression('and', title=text_value)
+        )
+
 
 class TestFieldValue(object):
 

--- a/tests/test_structured.py
+++ b/tests/test_structured.py
@@ -110,7 +110,7 @@ class TestFormatValue(object):
     def test_it__with_multi_encoding(self):
         from csquery.structured import Expression
         import six
-        binary_value = six.binary_type("あ")
+        binary_value = six.text_type("あ").encode("utf-8")
         text_value = six.text_type("あ")
 
         self._call_fut(


### PR DESCRIPTION
- add test
- fix bug, using six

if this module's supporting target type is only text_type(python2.x: unicode, python3.x: str),  commented sentenence is unneccessary.
