### PR TITLE
a query with  range of values, over escaped expression is generated.L

### DIFF
--- a/csquery/structured.py
+++ b/csquery/structured.py
@@ -34,8 +34,9 @@ def format_value(value):
         if (value.startswith('(') and value.endswith(')'))\
                 or (value.startswith('{') and value.endswith(']'))\
                 or (value.startswith('[') and value.endswith('}'))\
-                or (value.startswith('[') and value.endswith(']'))\
-                or ('=' in value):
+                or (value.startswith('[') and value.endswith(']')):
+            return six.text_type(value)
+        elif '=' in value:
             return six.text_type(escape(value))
     except AttributeError:
         return six.text_type(value)

--- a/tests/test_structured.py
+++ b/tests/test_structured.py
@@ -111,11 +111,23 @@ class TestFormatValue(object):
 
     def test_it_for_escape__with_range_values(self):
         from csquery.structured import and_
+
         assert "(and release_date:[\'2000-01-01T00:00:00Z\', \'2010-01-01T00:00:00Z\'})" == self._call_fut(
             and_(release_date="['2000-01-01T00:00:00Z', '2010-01-01T00:00:00Z'}")
         )
         assert "(and (and release_date:[\'2000-01-01T00:00:00Z\', \'2010-01-01T00:00:00Z\'}))" == self._call_fut(
             and_(and_(release_date="['2000-01-01T00:00:00Z', '2010-01-01T00:00:00Z'}"))
+        )
+
+        assert "(and (and release_date:[\'2000-01-01T00:00:00Z\', \'2010-01-01T00:00:00Z\'}))" == self._call_fut(
+            and_(and_(release_date="['2000-01-01T00:00:00Z', '2010-01-01T00:00:00Z'}"))
+        )
+
+        assert "(and _id:['tt1000000','tt1005000'])" == self._call_fut(
+            and_(_id="['tt1000000','tt1005000']")
+        )
+        assert "(and _id:['tt\'1000000','tt\'1005000'])" == self._call_fut(
+            and_(_id="['tt\'1000000','tt\'1005000']")
         )
 
     def test_it__with_multi_encoding(self):

--- a/tests/test_structured.py
+++ b/tests/test_structured.py
@@ -86,7 +86,9 @@ class TestFormatValue(object):
         )
         assert "'test'" == self._call_fut('test')
 
-        # escape value
+    def test_it_for_escape(self):
+        from csquery.structured import Expression, field
+
         assert r"(and title:'st\\ar')" == self._call_fut(
             Expression('and', title=r'st\ar')
         )

--- a/tests/test_structured.py
+++ b/tests/test_structured.py
@@ -109,6 +109,15 @@ class TestFormatValue(object):
             field("Alec'Guinness", 'actors')
         )
 
+    def test_it_for_escape__with_range_values(self):
+        from csquery.structured import and_
+        assert "(and release_date:[\'2000-01-01T00:00:00Z\', \'2010-01-01T00:00:00Z\'})" == self._call_fut(
+            and_(release_date="['2000-01-01T00:00:00Z', '2010-01-01T00:00:00Z'}")
+        )
+        assert "(and (and release_date:[\'2000-01-01T00:00:00Z\', \'2010-01-01T00:00:00Z\'}))" == self._call_fut(
+            and_(and_(release_date="['2000-01-01T00:00:00Z', '2010-01-01T00:00:00Z'}"))
+        )
+
     def test_it__with_multi_encoding(self):
         from csquery.structured import Expression
         import six


### PR DESCRIPTION
A query with  range of values, over escaped expression is generated.

example: 

```
k = "release_date"
v = "['2000-01-01T00:00:00Z', '2010-01-01T00:00:00Z'}"
q = cs.and_({k: v})
```

a output of current implementation is below.

```
(and release_date:[\'2000-01-01T00:00:00Z\', \'2010-01-01T00:00:00Z\'})
```

But, this is invalid format.  A correct format is this.

```
(and release_date:['2000-01-01T00:00:00Z', '2010-01-01T00:00:00Z'})
```
